### PR TITLE
fix(GUIDEFRAME-43): add permissions to publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,4 +39,7 @@ jobs:
       - name: Build and Publish to PyPI
         run: |
           poetry build
-          poetry publish --no-interaction
+          
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
- added additional action from pypi publish repo